### PR TITLE
fix: Adjust time formatting to include Amsterdam timezone

### DIFF
--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -51,5 +51,5 @@ export function mapDate(date: MeetupEvent["dateTime"]): { day: string; month: st
  */
 export function formatTime(time: string): string {
   const dateObject = new Date(time);
-  return dateObject.toLocaleTimeString("nl-NL", { hour: "2-digit", minute: "2-digit" });
+  return dateObject.toLocaleTimeString("nl-NL", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Amsterdam" });
 }


### PR DESCRIPTION
- [fix: Adjust time formatting to include Amsterdam timezone](https://github.com/eutm/eutm.eu/commit/a9635ada8e254a91bba46c964e9add4f384fc062)